### PR TITLE
Add generic secrets template (OpenAI, GitHub, AWS, Private Key)

### DIFF
--- a/generic-secrets.md
+++ b/generic-secrets.md
@@ -5,26 +5,26 @@
 ---
 
 ## OpenAI
-```ini
-OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ## GitHub Access Token
-```ini
+```
 GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ## Private Key Pair (RSA/EC/ED25519)
-```text
+```
 -----BEGIN PRIVATE KEY-----
 MIIEvAIB...FAKE...EXAMPLE...==
 -----END PRIVATE KEY-----
 ```
 
 ## AWS Access Keys
-```ini
-AWS_ACCESS_KEY_ID=AKIAxxxxxxxxxxxxxxxx
-AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+AWS_ACCESS_KEY_ID=AKIxxxxxxxxxxxxxxxxx
+AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ---


### PR DESCRIPTION
This PR adds or updates a `generic-secrets.md` file that contains sample placeholder values for:
- OpenAI API key
- GitHub access token
- Private key pair (RSA/EC/ED25519)
- AWS access keys

All values are templates, not actual secrets. Please review and use them for demonstration or CI/CD systems only. Real credentials should never be committed.